### PR TITLE
fix compile error when building against exceptions-0.6 or higher

### DIFF
--- a/Data/Cond.hs
+++ b/Data/Cond.hs
@@ -244,6 +244,8 @@ instance MonadThrow m => MonadThrow (CondT a m) where
 
 instance MonadCatch m => MonadCatch (CondT a m) where
     catch (CondT m) c = CondT $ m `catch` \e -> getCondT (c e)
+
+instance MonadMask m => MonadMask (CondT a m) where
     mask a = CondT $ mask $ \u -> getCondT (a $ q u)
       where q u = CondT . u . getCondT
     uninterruptibleMask a =

--- a/find-conduit.cabal
+++ b/find-conduit.cabal
@@ -33,7 +33,7 @@ Library
       , regex-posix
       , mtl
       , semigroups
-      , exceptions
+      , exceptions           >= 0.6
       , time
       , streaming-commons
       , transformers


### PR DESCRIPTION
Hi,
I looks like since exceptions-0.6 mask functions have been spit out from MonadCatch into another class: MonadMask. I've made a quick fix to make things compile again.
Cheers,
Boris