### PR TITLE
Change condition's monad to IO

### DIFF
--- a/Data/Cond.hs
+++ b/Data/Cond.hs
@@ -24,8 +24,8 @@ module Data.Cond
     -- * Helper functions
     , recurse, test
 
-    -- * Isomorphism with a stateful EitherT
-    , CondEitherT(..), fromCondT, toCondT
+    -- * Isomorphism with a stateful ExceptT
+    , CondExceptT(..), fromCondT, toCondT
     ) where
 
 import Control.Applicative (Alternative (..), optional)
@@ -39,7 +39,7 @@ import Control.Monad.State.Class (MonadState (..), gets)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans (MonadTrans (..))
 import Control.Monad.Trans.Control (MonadBaseControl (..))
-import Control.Monad.Trans.Either (EitherT, left, runEitherT)
+import Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import Control.Monad.Trans.State (StateT (..), withStateT, evalStateT)
 import Data.Foldable (asum, sequence_)
 import Data.Functor.Identity (Identity (..))
@@ -485,28 +485,28 @@ test = (liftM isJust .) . flip runCondT
 {-# INLINE test #-}
 
 -- | This type is for documentation only, and shows the isomorphism between
---   'CondT' and 'CondEitherT'.  The reason for using 'Result' is that it
+--   'CondT' and 'CondExceptT'.  The reason for using 'Result' is that it
 --   makes meaning of the constructors more explicit.
-newtype CondEitherT a m b = CondEitherT
-    (StateT a (EitherT (Maybe (Maybe (CondEitherT a m b))) m)
-         (b, Maybe (Maybe (CondEitherT a m b))))
+newtype CondExceptT a m b = CondExceptT
+    (StateT a (ExceptT (Maybe (Maybe (CondExceptT a m b))) m)
+         (b, Maybe (Maybe (CondExceptT a m b))))
 
--- | Witness one half of the isomorphism from 'CondT' to 'CondEitherT'.
-fromCondT :: Monad m => CondT a m b -> CondEitherT a m b
-fromCondT (CondT f) = CondEitherT $ do
+-- | Witness one half of the isomorphism from 'CondT' to 'CondExceptT'.
+fromCondT :: Monad m => CondT a m b -> CondExceptT a m b
+fromCondT (CondT f) = CondExceptT $ do
     s <- get
     (r, s') <- lift $ lift $ runStateT f s
     case r of
-        Ignore             -> lift $ left Nothing
+        Ignore             -> lift $ (ExceptT . return . Left) Nothing
         Keep a             -> put s' >> return (a, Nothing)
-        RecurseOnly m      -> lift $ left (Just (fmap fromCondT m))
+        RecurseOnly m      -> lift $ (ExceptT . return . Left) (Just (fmap fromCondT m))
         KeepAndRecurse a m -> put s' >> return (a, Just (fmap fromCondT m))
 
--- | Witness the other half of the isomorphism from 'CondEitherT' to 'CondT'.
-toCondT :: Monad m => CondEitherT a m b -> CondT a m b
-toCondT (CondEitherT f) = CondT $ do
+-- | Witness the other half of the isomorphism from 'CondExceptT' to 'CondT'.
+toCondT :: Monad m => CondExceptT a m b -> CondT a m b
+toCondT (CondExceptT f) = CondT $ do
     s <- get
-    eres <- lift $ runEitherT $ runStateT f s
+    eres <- lift $ runExceptT $ runStateT f s
     case eres of
         Left Nothing             -> return Ignore
         Right ((a, Nothing), s') -> put s' >> return (Keep a)

--- a/conduit-find.cabal
+++ b/conduit-find.cabal
@@ -47,9 +47,7 @@ Library
       , streaming-commons
       , transformers
       , transformers-base
-      , transformers-either  == 0.1.*
       , mmorph
-      , either
       , monad-control        >= 1.0
       , filepath
     exposed-modules:

--- a/conduit-find.cabal
+++ b/conduit-find.cabal
@@ -1,5 +1,5 @@
 Name:                conduit-find
-Version:             0.1.0.3
+Version:             0.1.1.0
 Synopsis:            A file-finding conduit that allows user control over traversals.
 License-file:        LICENSE
 License:             MIT
@@ -32,7 +32,7 @@ Library
         cpp-options: -DLEAFOPT=1
     build-depends:
         base                 >= 3 && < 5
-      , conduit              == 1.2.*
+      , conduit              == 1.3.*
       , conduit-extra
       , conduit-combinators
       , attoparsec
@@ -43,11 +43,11 @@ Library
       , semigroups
       , exceptions           >= 0.6
       , time
-      , resourcet            == 1.1.*
+      , resourcet            == 1.2.*
       , streaming-commons
       , transformers
       , transformers-base
-      , transformers-either  == 0.0.2
+      , transformers-either  == 0.1.*
       , mmorph
       , either
       , monad-control        >= 1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,14 @@
+resolver: lts-12.1
+
+packages:
+- '.'
+
+extra-deps:
+- transformers-either-0.1.1
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,9 @@
-resolver: lts-12.1
+resolver: lts-12.12
 
 packages:
 - '.'
 
-extra-deps:
-- transformers-either-0.1.1
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/doctest.hs
+++ b/test/doctest.hs
@@ -10,9 +10,6 @@ import Data.List
 main :: IO ()
 main = getSources >>= \sources -> doctest $
     "-iData"
-  : "-idist/build/autogen"
-  : "-optP-include"
-  : "-optPdist/build/autogen/cabal_macros.h"
   : sources
 
 getSources :: IO [FilePath]


### PR DESCRIPTION
Hi,
To support lts-12 and new resourcet(1.2.*) which does not support StateT,
change ```CondT FileEntry m a``` to ```CondT FileEntry IO a``` and split conduit-monad and condt-monad in find-function.
